### PR TITLE
Resolve bare specifiers through package.json exports maps

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,4 @@ docs/
 tmp/
 /worker.js
 node_modules/
+test/resources/

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -2,6 +2,7 @@ module.exports = {
   timeout: 2000,
   reporter: "spec",
   recursive: true,
+  ignore: [ "test/resources/**" ],
   "node-option": ["experimental-vm-modules", "no-warnings"],
 };
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 # Unreleased
 
+- Resolve bare specifiers through `package.json` `exports` maps, including nested condition objects (`import`/`default`/`node`), arrays, and `null` "not exported" targets. Existing packages that only have `main`/`module`/`jsnext:main` keep resolving via the legacy path.
+- Stop swallowing bare-specifier resolution errors. Unresolvable specifiers now throw `ERR_MODULE_NOT_FOUND` naming the specifier and the importing file, instead of silently falling through to a relative-path lookup that ENOENTs at read time.
 - lint some
 - upgrade dev dependencies
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,14 @@ is exported as:
 export default { content_of_data_json: true };
 ````
 
+## Bare specifiers
+
+Bare specifiers (`smqp`, `@scope/pkg`, `@scope/pkg/sub`) are resolved against the importing file's `node_modules`. Wichita honors the package's `package.json` `exports` map when present — including nested condition objects (`import`, `default`, `node`), array fallbacks, and `null` targets that explicitly mark a subpath as not exported. Conditions are matched in declaration order with `["node", "import"]` plus an implicit `default` fallback.
+
+For packages without an `exports` field, Wichita keeps using the legacy `module` / `jsnext:main` / `index.js` lookup, so existing tests against pre-`exports` packages keep working.
+
+If a bare specifier cannot be resolved, Wichita throws an `ERR_MODULE_NOT_FOUND` error naming the specifier and the importing file, rather than falling through to a relative-path lookup.
+
 # Tip for Tallahaassee users
 
 To ensure that that console logs from clientside scripts are visibile when running a test with Tallaahaassee+Witchita you should add `browser.window.console = console;` to your `runScript` function

--- a/index.js
+++ b/index.js
@@ -2,13 +2,15 @@
 
 const vm = require("vm");
 const url = require("url");
-const {promises: fs} = require("fs");
+const Module = require("module");
+const {promises: fs, existsSync, readFileSync} = require("fs");
 
 const {name, version} = require("./package.json");
 const wichita = `${name} v${version}`;
 const {dirname, extname, resolve: resolvePath, isAbsolute, sep, posix} = require("path");
 
 const ErrorPrepareStackTrace = Error.prepareStackTrace;
+const RESOLUTION_CONDITIONS = ["node", "import"];
 
 module.exports = Script;
 
@@ -125,10 +127,8 @@ Loader.prototype.getScriptSource = async function getScriptSource(scriptPath) {
 function getFullPath(sourcePath, calledFrom) {
   if (isAbsolute(sourcePath)) return sourcePath;
 
-  const isRelativePath = isRelative(sourcePath);
-  const resolvedPath = !isRelativePath && getModulePath(sourcePath);
-  if (resolvedPath) {
-    return resolvedPath;
+  if (!isRelative(sourcePath)) {
+    return getModulePath(sourcePath, calledFrom);
   }
 
   let file = resolvePath(dirname(calledFrom), sourcePath.split("/").join(sep));
@@ -141,25 +141,140 @@ function isRelative(p) {
   return p0 === "." || p0 === "..";
 }
 
-function getModulePath(sourcePath) {
-  try {
-    const parts = sourcePath.split("/");
-    let potentialModuleName = parts.shift();
-
-    if (potentialModuleName.indexOf("@") === 0) {
-      potentialModuleName += `/${parts.shift()}`;
-    }
-
-    const requirePath = require.resolve(`${potentialModuleName}/package.json`);
-    const resolvedPackage = require(`${potentialModuleName}/package.json`);
-    const externalModule = resolvedPackage && (resolvedPackage.module || resolvedPackage["jsnext:main"]) || "index.js";
-
-    let theRest = parts.join(sep);
-    if (theRest && !extname(theRest)) theRest += extname(externalModule);
-    return resolvePath(dirname(requirePath), theRest || externalModule);
-  } catch (e) {
-    // do nothing
+function getModulePath(sourcePath, calledFrom) {
+  const parts = sourcePath.split("/");
+  let pkgName = parts.shift();
+  if (pkgName.startsWith("@")) {
+    pkgName += `/${parts.shift()}`;
   }
+  const subpath = parts.length ? `./${parts.join("/")}` : ".";
+
+  const req = Module.createRequire(calledFrom);
+  const pkgRoot = findPackageRoot(req, pkgName);
+  if (!pkgRoot) {
+    throw resolveError(sourcePath, calledFrom, `package "${pkgName}" not found in node_modules`);
+  }
+
+  const pkg = JSON.parse(readFileSync(resolvePath(pkgRoot, "package.json"), "utf8"));
+
+  if (pkg.exports !== null && pkg.exports !== undefined) {
+    const target = resolveExports(pkg.exports, subpath, RESOLUTION_CONDITIONS);
+    if (target === null) {
+      throw resolveError(sourcePath, calledFrom, `subpath "${subpath}" of package "${pkgName}" is not exported (matched a null target in the exports field)`);
+    }
+    if (target === undefined) {
+      throw resolveError(sourcePath, calledFrom, `no matching export for "${subpath}" in package "${pkgName}"`);
+    }
+    return resolvePath(pkgRoot, target);
+  }
+
+  // Legacy path: prefer ESM-friendly entry, never fall back to CJS-only "main".
+  const main = pkg.module || pkg["jsnext:main"] || "index.js";
+  if (subpath === ".") {
+    return resolvePath(pkgRoot, main);
+  }
+  let theRest = parts.join(sep);
+  if (theRest && !extname(theRest)) theRest += extname(main);
+  return resolvePath(pkgRoot, theRest);
+}
+
+function findPackageRoot(req, pkgName) {
+  try {
+    return dirname(req.resolve(`${pkgName}/package.json`));
+  } catch (e) {
+    if (e.code === "MODULE_NOT_FOUND") return undefined;
+    if (e.code !== "ERR_PACKAGE_PATH_NOT_EXPORTED") throw e;
+  }
+  // Package's exports map blocks ./package.json — walk node_modules paths manually.
+  const paths = (req.resolve.paths(pkgName) || []);
+  for (const p of paths) {
+    const candidate = resolvePath(p, ...pkgName.split("/"));
+    if (existsSync(resolvePath(candidate, "package.json"))) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function resolveExports(exportsField, subpath, conditions) {
+  if (typeof exportsField === "string" || Array.isArray(exportsField)) {
+    if (subpath !== ".") return undefined;
+    return resolveTarget(exportsField, "", conditions);
+  }
+  if (exportsField === null || typeof exportsField !== "object") return undefined;
+
+  const keys = Object.keys(exportsField);
+  const hasSubpath = keys.some((k) => k.startsWith("."));
+  const hasCondition = keys.some((k) => !k.startsWith("."));
+  if (hasSubpath && hasCondition) {
+    throw new Error("Invalid \"exports\" field: keys must not mix subpaths and conditions");
+  }
+
+  if (hasSubpath) {
+    if (Object.prototype.hasOwnProperty.call(exportsField, subpath)) {
+      return resolveTarget(exportsField[subpath], "", conditions);
+    }
+    let bestKey;
+    let bestStar = "";
+    let bestPrefixLen = -1;
+    for (const k of keys) {
+      const star = k.indexOf("*");
+      if (star === -1) continue;
+      const prefix = k.slice(0, star);
+      const suffix = k.slice(star + 1);
+      if (subpath.length < prefix.length + suffix.length) continue;
+      if (!subpath.startsWith(prefix)) continue;
+      if (!subpath.endsWith(suffix)) continue;
+      if (prefix.length > bestPrefixLen) {
+        bestKey = k;
+        bestPrefixLen = prefix.length;
+        bestStar = subpath.slice(prefix.length, subpath.length - suffix.length);
+      }
+    }
+    if (bestKey !== undefined) {
+      return resolveTarget(exportsField[bestKey], bestStar, conditions);
+    }
+    return undefined;
+  }
+
+  if (subpath !== ".") return undefined;
+  return resolveTarget(exportsField, "", conditions);
+}
+
+function resolveTarget(target, star, conditions) {
+  if (target === null) return null;
+  if (typeof target === "string") {
+    if (!target.startsWith("./")) return undefined;
+    return target.split("*").join(star);
+  }
+  if (Array.isArray(target)) {
+    let nullSeen = false;
+    for (const item of target) {
+      const r = resolveTarget(item, star, conditions);
+      if (r === null) {
+        nullSeen = true;
+        continue;
+      }
+      if (r !== undefined) return r;
+    }
+    return nullSeen ? null : undefined;
+  }
+  if (typeof target === "object") {
+    for (const key of Object.keys(target)) {
+      if (key === "default" || conditions.includes(key)) {
+        const r = resolveTarget(target[key], star, conditions);
+        if (r !== undefined) return r;
+      }
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
+function resolveError(specifier, calledFrom, reason) {
+  const err = new Error(`Cannot resolve module "${specifier}" imported from "${calledFrom}": ${reason}`);
+  err.code = "ERR_MODULE_NOT_FOUND";
+  return err;
 }
 
 function getCalledFrom() {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
   },
   "devDependencies": {
     "@bonniernews/md2html": "0.0.8",
+    "@fixture/conditions": "file:test/resources/@fixture/conditions",
+    "@fixture/exports-only": "file:test/resources/@fixture/exports-only",
     "eslint": "^8.23.0",
     "eslint-config-exp": "^0.4.0",
     "mocha": "^10.0.0",

--- a/resources/blocked-import.js
+++ b/resources/blocked-import.js
@@ -1,0 +1,1 @@
+import "@fixture/conditions/blocked";

--- a/resources/conditions-import.js
+++ b/resources/conditions-import.js
@@ -1,0 +1,3 @@
+import { value } from "@fixture/conditions";
+
+window.conditionsValue = value;

--- a/resources/exports-only-import.js
+++ b/resources/exports-only-import.js
@@ -1,0 +1,3 @@
+import value from "@fixture/exports-only/foo";
+
+window.fixtureValue = value;

--- a/resources/missing-bare-import.js
+++ b/resources/missing-bare-import.js
@@ -1,0 +1,1 @@
+import "@fixture/does-not-exist";

--- a/test/exportsMapTest.js
+++ b/test/exportsMapTest.js
@@ -1,0 +1,59 @@
+"use strict";
+
+const assert = require("assert");
+const Script = require("..");
+
+describe("package.json exports field", () => {
+  it("resolves a bare specifier through the exports map (subpath)", async () => {
+    const source = new Script("../resources/exports-only-import.js");
+
+    const context = { window: {} };
+
+    await source.run(context);
+
+    assert.equal(context.window.fixtureValue, "ok");
+  });
+
+  it("resolves nested conditions, picking 'import' over 'default'", async () => {
+    const source = new Script("../resources/conditions-import.js");
+
+    const context = { window: {} };
+
+    await source.run(context);
+
+    assert.equal(context.window.conditionsValue, "node-import");
+  });
+
+  it("rejects subpaths whose exports target is null", async () => {
+    const source = new Script("../resources/blocked-import.js");
+
+    await assert.rejects(() => source.run({ window: {} }), (err) => {
+      assert.equal(err.code, "ERR_MODULE_NOT_FOUND");
+      assert.ok(/blocked/.test(err.message), `expected message to mention specifier, got: ${err.message}`);
+      assert.ok(/@fixture\/conditions/.test(err.message), `expected message to mention package, got: ${err.message}`);
+      return true;
+    });
+  });
+
+  it("throws a clear error for an unresolvable bare specifier, naming specifier and importer", async () => {
+    const source = new Script("../resources/missing-bare-import.js");
+
+    await assert.rejects(() => source.run({ window: {} }), (err) => {
+      assert.equal(err.code, "ERR_MODULE_NOT_FOUND");
+      assert.ok(/@fixture\/does-not-exist/.test(err.message), `expected message to mention specifier, got: ${err.message}`);
+      assert.ok(/missing-bare-import\.js/.test(err.message), `expected message to mention importer, got: ${err.message}`);
+      return true;
+    });
+  });
+
+  it("still resolves packages that only have main/module/jsnext:main (no exports)", async () => {
+    // smqp is one such package — uses module + jsnext:main, no exports field.
+    const source = new Script("../resources/static-import.js", { moduleRoute: "/module/" });
+
+    const context = { window: {} };
+
+    await source.run(context);
+
+    assert.ok(context.window.broker, "expected smqp Broker to load via legacy fields");
+  });
+});

--- a/test/resources/@fixture/conditions/cjs/index.js
+++ b/test/resources/@fixture/conditions/cjs/index.js
@@ -1,0 +1,1 @@
+module.exports = { value: "cjs-fallback" };

--- a/test/resources/@fixture/conditions/esm/index.js
+++ b/test/resources/@fixture/conditions/esm/index.js
@@ -1,0 +1,2 @@
+export const value = "node-import";
+export default value;

--- a/test/resources/@fixture/conditions/package.json
+++ b/test/resources/@fixture/conditions/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@fixture/conditions",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "node": {
+        "import": "./esm/index.js",
+        "default": "./cjs/index.js"
+      },
+      "default": "./cjs/index.js"
+    },
+    "./blocked": null
+  }
+}

--- a/test/resources/@fixture/exports-only/dist/foo.js
+++ b/test/resources/@fixture/exports-only/dist/foo.js
@@ -1,0 +1,1 @@
+export default "ok";

--- a/test/resources/@fixture/exports-only/package.json
+++ b/test/resources/@fixture/exports-only/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@fixture/exports-only",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    "./foo": { "import": "./dist/foo.js", "default": "./dist/foo.js" }
+  }
+}


### PR DESCRIPTION
## Summary

- Bare-specifier resolution now applies the conditional resolution algorithm against `package.json#exports`. Conditions `["node", "import"]` plus an implicit `default` fallback are matched in declaration order. String, object and array target forms are honored; `null` targets surface as `ERR_MODULE_NOT_FOUND`; pattern subpaths (`./*`) are supported. Packages without an `exports` field keep the legacy `module` / `jsnext:main` / `index.js` path, so existing tests against pre-exports packages keep passing.
- When a package's `exports` map blocks `./package.json` (e.g. `@bonniernews-internal/bn-analytics-definitions@1.x`), the resolver falls back to walking the require search paths via `fs.existsSync` to locate the package root, instead of silently returning `undefined` and falling through to a relative-path lookup that ENOENTs at read time.
- The `try { ... } catch { /* do nothing */ }` around `getModulePath` is gone. Unresolvable bare specifiers now throw `ERR_MODULE_NOT_FOUND` naming the specifier and the importing file. This is the fix for the confusing downstream ENOENTs that triggered the `fileCache` workaround in `BonnierNews/exp-web` (`packages/test/helpers/setup.js`).
- No new runtime dependencies. Two tiny fixture packages live under `test/resources/@fixture/*` and are linked into `node_modules` via `file:` dev dependencies.

## Test plan

- [x] `npm test` — 36 passing, lint clean
- [x] New `test/exportsMapTest.js` covers:
  - regression: subpath import on a package whose `exports` map does not expose `./package.json` (the original bug)
  - nested conditions, picking `import` over `default`
  - subpath whose target is `null` → `ERR_MODULE_NOT_FOUND` mentioning specifier + package
  - unresolvable bare specifier → clear error naming specifier + importing file
  - legacy path still works for packages with only `module`/`jsnext:main` (`smqp`)
- [ ] Once merged and consumed, remove the `fileCache` pre-seed workaround from `BonnierNews/exp-web` `packages/test/helpers/setup.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)